### PR TITLE
serializer, entity_fabric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.0 - 2019-07-18
+### Added
+- repka.api.BaseRepository.serializer property for defining serialization behaviour
+- repka.api.BaseRepository.deserializer property for defining deserialization behaviour
+
+### Removed
+- repka.api.BaseRepository.entity_type property. The same functionality can be provided by deserializer property
+
 ## 0.1.0 - 2019-07-02
 
 ### Added 

--- a/repka/api.py
+++ b/repka/api.py
@@ -1,7 +1,17 @@
 import json
 from abc import abstractmethod
 from functools import reduce, partial
-from typing import TypeVar, Optional, Generic, Dict, Sequence, List, cast, Tuple, Callable
+from typing import (
+    TypeVar,
+    Optional,
+    Generic,
+    Dict,
+    Sequence,
+    List,
+    cast,
+    Tuple,
+    Callable,
+)
 
 from aiopg.sa import SAConnection
 from aiopg.sa.result import ResultProxy
@@ -89,9 +99,9 @@ class BaseRepository(Generic[T]):
         return await self.first(self.table.c.id == entity_id)
 
     async def get_or_create(
-            self,
-            filters: Optional[List[BinaryExpression]] = None,
-            defaults: Optional[Dict] = None
+        self,
+        filters: Optional[List[BinaryExpression]] = None,
+        defaults: Optional[Dict] = None,
     ) -> Tuple[T, Created]:
         filters = filters or []
         defaults = defaults or {}
@@ -105,16 +115,18 @@ class BaseRepository(Generic[T]):
         return entity, True
 
     async def get_all(
-            self,
-            filters: Optional[List[BinaryExpression]] = None,
-            orders: Optional[List[BinaryExpression]] = None,
+        self,
+        filters: Optional[List[BinaryExpression]] = None,
+        orders: Optional[List[BinaryExpression]] = None,
     ) -> List[T]:
         filters = filters or []
         orders = orders or []
 
         query = self.table.select()
         query = self._apply_filters(query, filters)
-        query = reduce(lambda query_, order_by: query_.order_by(order_by), orders, query)
+        query = reduce(
+            lambda query_, order_by: query_.order_by(order_by), orders, query
+        )
 
         rows = await self.connection.execute(query)
         return [cast(T, self.deserializer(**row)) for row in rows]
@@ -125,7 +137,7 @@ class BaseRepository(Generic[T]):
         await self.connection.execute(query)
 
     def _apply_filters(
-            self, query: ClauseElement, filters: Sequence[BinaryExpression]
+        self, query: ClauseElement, filters: Sequence[BinaryExpression]
     ) -> ClauseElement:
         return reduce(lambda query_, filter_: query_.where(filter_), filters, query)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,7 +39,7 @@ transactions_table = sa.Table(
 
 
 class TransactionRepo(BaseRepository[Transaction]):
-    entity_type = Transaction
+    deserializer = Transaction
     table = transactions_table
 
     async def sum(self) -> int:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -71,13 +71,15 @@ async def transactions(repo: TransactionRepo) -> List[Transaction]:
     transactions_ = [
         Transaction(price=100, date=dt.date(2019, 1, 3)),
         Transaction(price=200),
-        Transaction(price=100, date=dt.date(2019, 1, 1))
+        Transaction(price=100, date=dt.date(2019, 1, 1)),
     ]
     transactions_ = await repo.insert_many(transactions_)
     return transactions_
 
 
-async def test_base_repository_insert_sets_id_and_inserts_to_db(repo: TransactionRepo) -> None:
+async def test_base_repository_insert_sets_id_and_inserts_to_db(
+    repo: TransactionRepo
+) -> None:
     trans = Transaction(price=100)
 
     trans = await repo.insert(trans)
@@ -110,41 +112,50 @@ async def test_base_repo_update_updates_row_in_db(repo: TransactionRepo) -> None
     assert updated_trans.date == trans.date
 
 
-async def test_base_repo_first_return_first_matching_row(repo: TransactionRepo,
-                                                         transactions: List[Transaction]) -> None:
+async def test_base_repo_first_return_first_matching_row(
+    repo: TransactionRepo, transactions: List[Transaction]
+) -> None:
     trans = await repo.first(transactions_table.c.price == 100)
 
     assert trans.id == transactions[0].id
 
 
-async def test_base_repo_get_all_return_all_rows_filtered_and_sorted(repo: TransactionRepo,
-                                                                     transactions: List[Transaction]) -> None:
+async def test_base_repo_get_all_return_all_rows_filtered_and_sorted(
+    repo: TransactionRepo, transactions: List[Transaction]
+) -> None:
     db_transactions = await repo.get_all(
-        filters=[transactions_table.c.price == 100],
-        orders=[transactions_table.c.date]
+        filters=[transactions_table.c.price == 100], orders=[transactions_table.c.date]
     )
     assert db_transactions == [transactions[2], transactions[0]]
 
 
-async def test_base_repo_delete_deletes_row_from_db(repo: TransactionRepo, transactions: List[Transaction]) -> None:
+async def test_base_repo_delete_deletes_row_from_db(
+    repo: TransactionRepo, transactions: List[Transaction]
+) -> None:
     await repo.delete(transactions_table.c.price == 100)
 
     db_transactions = await repo.get_all()
     assert len(db_transactions) == 1
 
 
-async def test_transaction_repo_custom_method_works(repo: TransactionRepo, transactions: List[Transaction]) -> None:
+async def test_transaction_repo_custom_method_works(
+    repo: TransactionRepo, transactions: List[Transaction]
+) -> None:
     sum_ = await repo.sum()
 
     assert sum_ == sum(map(operator.attrgetter("price"), transactions))
 
 
-async def test_base_repo_get_by_id_returns_row_with_id(repo: TransactionRepo, transactions: List[Transaction]) -> None:
+async def test_base_repo_get_by_id_returns_row_with_id(
+    repo: TransactionRepo, transactions: List[Transaction]
+) -> None:
     db_trans = await repo.get_by_id(transactions[0].id)
     assert db_trans == transactions[0]
 
 
-async def test_base_repo_get_or_create_creates_entity_if_no_entities(repo: TransactionRepo) -> None:
+async def test_base_repo_get_or_create_creates_entity_if_no_entities(
+    repo: TransactionRepo
+) -> None:
     price = 400
     trans, created = await repo.get_or_create(defaults={"price": price})
     assert created
@@ -152,13 +163,12 @@ async def test_base_repo_get_or_create_creates_entity_if_no_entities(repo: Trans
 
 
 async def test_base_repo_get_or_create_returns_entity_if_match(
-        repo: TransactionRepo,
-        transactions: List[Transaction]
+    repo: TransactionRepo, transactions: List[Transaction]
 ) -> None:
     price = 400
     trans, created = await repo.get_or_create(
         filters=[transactions_table.c.id == transactions[0].id],
-        defaults={"price": price}
+        defaults={"price": price},
     )
     assert not created
     assert trans == transactions[0]


### PR DESCRIPTION
Я подумал и понял, что нужно не заморачиваться, и сделать serializer/entity_fabric обычными функциями. 
Подтягивать какие-то внешние поля через дополнительные методы конкретных репозиториев (напр., MenuItem.set_venue_settings, которое устанавливает VenueSettings для айтема)